### PR TITLE
Hacky attempt at getting GCW Zero support working

### DIFF
--- a/projects/Makefile
+++ b/projects/Makefile
@@ -115,6 +115,20 @@ DINGOODIRS      :=    . \
 				../sources/Adapters/SDL/GUI \
 				../sources/Adapters/SDL/Timer
 
+GCWZERODIRS     :=    . \
+				../sources/Adapters/DINGOO/Main \
+				../sources/Adapters/Unix/FileSystem \
+				../sources/System/Process \
+				../sources/Adapters/Unix/Process \
+				../sources/Adapters/DINGOO/System \
+				../sources/Adapters/DINGOO/Midi \
+				../sources/Adapters/Dummy/Midi \
+				../sources/Adapters/DINGOO/Audio \
+				../sources/Adapters/SDL/Audio \
+				../sources/Adapters/SDL/Process \
+				../sources/Adapters/SDL/GUI \
+				../sources/Adapters/SDL/Timer
+
 PSPDIRS	:=    . \
 				../sources/Adapters/PSP/Main \
 				../sources/Adapters/PSP/FileSystem \
@@ -184,6 +198,22 @@ COMMONDIRS	:=	../sources/System/Console \
 #---------------------------------------------------------------------------------
 
 DINGOOFILES             :=  GPSDLMain.o \
+					UnixFileSystem.o \
+					DummyMidi.o \
+					DINGOOAudio.o \
+					Process.o \
+					UnixProcess.o \
+					SDLAudioDriver.o \
+					DINGOOAudioDriver.o \
+					DINGOOSystem.o \
+					DINGOOEventQueue.o \
+					SDLProcess.o \
+					SDLTimer.o \
+					GUIFactory.o \
+					SDLEventManager.o \
+					SDLGUIWindowImp.o
+
+GCWZEROFILES            :=  GPSDLMain.o \
 					UnixFileSystem.o \
 					DummyMidi.o \
 					DINGOOAudio.o \

--- a/projects/Makefile
+++ b/projects/Makefile
@@ -4,7 +4,7 @@
 .SUFFIXES:
 #---------------------------------------------------------------------------------
 
-PLATFORM:=  RASPI
+PLATFORM:=  GCWZERO
 
 include $(PWD)/Makefile.$(PLATFORM)
 

--- a/projects/Makefile.GCWZERO
+++ b/projects/Makefile.GCWZERO
@@ -7,7 +7,7 @@ SDL_BASE = /opt/gcw0-toolchain/usr/bin/
 
 include $(PWD)/dingoo_rules
 
-CFLAGS	:=	`sdl-config --cflags` -O3 -D_DEBUG -Wall -DPLATFORM_$(PLATFORM) -I$(PWD)/../sources -D__LINUX_ALSA__  -DCPP_MEMORY
+CFLAGS	:=	`sdl-config --cflags` -O3 -fpermissive -D_DEBUG -Wall -DPLATFORM_$(PLATFORM) -I$(PWD)/../sources -D__LINUX_ALSA__  -DCPP_MEMORY
 
 CXXFLAGS:=	$(CFLAGS)
 

--- a/projects/Makefile.GCWZERO
+++ b/projects/Makefile.GCWZERO
@@ -5,7 +5,7 @@ TOOLPATH=$(DEVKIT)/usr/bin
 PREFIX		:=	
 SDL_BASE = /opt/gcw0-toolchain/usr/bin/
 
-include $(PWD)/dingoo_rules
+include $(PWD)/gcwzero_rules
 
 CFLAGS	:=	`sdl-config --cflags` -O3 -D_DEBUG -Wall -DPLATFORM_$(PLATFORM) -I$(PWD)/../sources -D__LINUX_ALSA__  -DCPP_MEMORY
 

--- a/projects/Makefile.GCWZERO
+++ b/projects/Makefile.GCWZERO
@@ -1,0 +1,17 @@
+
+DEVKIT=/opt/gcw0-toolchain
+
+TOOLPATH=$(DEVKIT)/usr/bin
+PREFIX		:=	
+SDL_BASE = /opt/gcw0-toolchain/usr/bin/
+
+include $(PWD)/dingoo_rules
+
+CFLAGS	:=	`sdl-config --cflags` -O3 -D_DEBUG -Wall -DPLATFORM_$(PLATFORM) -I$(PWD)/../sources -D__LINUX_ALSA__  -DCPP_MEMORY
+
+CXXFLAGS:=	$(CFLAGS)
+
+EXTENSION:= dge
+
+LIBS	:=  -L/opt/gcw0-toolchain/usr/lib -lSDL -lpthread 
+LIBDIRS	:=	$(DEKVIT)/usr/lib

--- a/projects/gcwzero_rules
+++ b/projects/gcwzero_rules
@@ -1,0 +1,9 @@
+-include $(PWD)/base_rules
+
+#STRIP = mipsel-linux-strip
+STRIP = ls
+
+#---------------------------------------------------------------------------------
+%.dge: $(OFILES)
+	$(CXX) $(LDFLAGS) -o $@ $(OFILES) $(LIBS)
+	@$(STRIP) $@

--- a/projects/gcwzero_rules
+++ b/projects/gcwzero_rules
@@ -1,6 +1,5 @@
 -include $(PWD)/base_rules
 
-#STRIP = mipsel-linux-strip
 STRIP = ls
 
 #---------------------------------------------------------------------------------

--- a/sources/System/Console/Trace.cpp
+++ b/sources/System/Console/Trace.cpp
@@ -45,7 +45,7 @@ void Trace::VLog(const char* category,  const char *fmt, const va_list& args)
   
   char *ptr = buffer+strlen(buffer);
   
-  //vsprintf(ptr,fmt,args ); 
+  vsprintf(ptr,fmt,args ); 
   GetInstance()->AddLine(buffer) ;
   
 }

--- a/sources/System/Console/Trace.cpp
+++ b/sources/System/Console/Trace.cpp
@@ -45,7 +45,7 @@ void Trace::VLog(const char* category,  const char *fmt, const va_list& args)
   
   char *ptr = buffer+strlen(buffer);
   
-  vsprintf(ptr,fmt,args ); 
+  //vsprintf(ptr,fmt,args ); 
   GetInstance()->AddLine(buffer) ;
   
 }


### PR DESCRIPTION
This is just a first hacky attempt at getting GCW Zero to compile.

I did the following:

On Xubuntu, I downloaded and installed the GCW Zero toolchain following all instructions on this page: http://www.gcw-zero.com/develop including adding `/opt/gcw0-toolchain/usr/bin` to my `$PATH`.

I also `sudo apt-get install sdl-1.2dev`.

I switch into `~/Projects/LittleGPTracker/projects`, and run `make`.
